### PR TITLE
 Small changes and fixes: 

### DIFF
--- a/mods/factions/factions.lua
+++ b/mods/factions/factions.lua
@@ -340,7 +340,7 @@ end
 function factions.Faction.can_claim_parcel(self, parcelpos)
     local fac = factions.parcels[parcelpos]
     if fac then
-        if factions.factions[fac].power < 0. and self.power >= factions.power_per_parcel then
+        if factions.factions[fac].power < 0. and self.power >= factions.power_per_parcel and self.enemies[fac.name] then
             return true
         else
             return false
@@ -1212,7 +1212,7 @@ function(player)
 	-- 300 seconds = 5 minutes
 	-- Kill unstamped players.
     if parcel_faction and parcel_faction.is_admin == false and (value == 0 or os.time() - value >= 300) then
-        if (not faction or parcel_faction.name ~= facname) and parcel_faction.enemies[facname] then
+        if (not faction or parcel_faction.name ~= facname) and (facname == "" or parcel_faction.enemies[facname]) then
             minetest.after(1, function()
                 if player then
                     player:set_hp(0)

--- a/mods/factions/siege.lua
+++ b/mods/factions/siege.lua
@@ -93,11 +93,11 @@ minetest.register_craftitem("factions:siege_banner", {
 
         local meta = minetest.get_meta(pointed_thing.above)
 
-		meta:set_int("stage",0)
+		meta:set_int("stage",1)
         meta:set_string("attacking_faction", attacking_faction.name)
         meta:set_string("defending_faction", defending_faction.name)
             
-        minetest.get_meta(pointed_thing.above):set_string("infotext", "Siege Banner 1/4 (" .. attacking_faction.name .. " vs " .. defending_faction.name .. ")")
+        meta:set_string("infotext", "Siege Banner 1/4 (" .. attacking_faction.name .. " vs " .. defending_faction.name .. ")")
 
         return "" 
     end
@@ -125,7 +125,7 @@ minetest.register_node("factions:siege_banner_sieging", {
 		stage = stage + 1
 
 		if stage <= siege_banner_stages then
-			minetest.get_meta(pos):set_string("infotext", "Siege Banner " .. stage .. "/" .. siege_banner_stages .. " (" .. att_fac_name .. " vs " .. def_fac_name .. ")")
+			meta:set_string("infotext", "Siege Banner " .. stage .. "/" .. siege_banner_stages .. " (" .. att_fac_name .. " vs " .. def_fac_name .. ")")
 			factions.get_faction(def_fac_name):broadcast("Your parcel at " .. format_pos(pos) .. " is being sieged (" .. stage .. "/" .. siege_banner_stages .. ")")
 			meta:set_int("stage",stage)
 			meta:set_string("attacking_faction", att_fac_name)


### PR DESCRIPTION
I ran a small test on my computer. Players not in a faction will not be kill after 5 minutes on another factions land because it failed to check whether player's faction was blank. It would check if the blank faction was an enemy which would return false and fail to kill the player.

I made a change in the can_claim_parcel function. Now you could only claim over low-powered faction land if your faction is at war with them.

Small bug fix with siege banner. The siege stage started at zero which made it take longer. before the fix it would stay on stage 1 longer then the other stages.